### PR TITLE
Fixes traits() with ES6 classes (STILL BROKEN)

### DIFF
--- a/src/main/trait.ts
+++ b/src/main/trait.ts
@@ -12,12 +12,25 @@ export default function traits<T extends Array<Class<any>>> (constructors: T): C
   const cls = class {
     constructor () {
       constructors.forEach((c: any) => {
-        Reflect.construct(c, [], this)
+        const tmp = Reflect.construct(c, [], new.target)
+        let keys: string[] = []
+        for (let key of Object.keys(tmp)) {
+          const desc = Object.getOwnPropertyDescriptor(tmp, key)
+          if (desc !== undefined) {
+            Object.defineProperty(this, key, desc)
+          }
+          keys.push(key)
+        }
       })
     }
   }
   constructors.forEach((c: any) => {
-    Object.assign(cls.prototype, c.prototype)
+    for (let key of Object.keys(c.prototype)) {
+      const desc = Object.getOwnPropertyDescriptor(c.prototype, key)
+      if (desc !== undefined) {
+        Object.defineProperty(cls.prototype, key, desc)
+      }
+    }
   })
   return cls as any
 }


### PR DESCRIPTION
ES6 classes require `new` which means the usual ES5 idiom of constructor forwarding using `base_ctor.apply(this)` doesn't work.  The only way to make it work is to use `Reflect.construct()` and shallow-copy the own properties over manually.

**Important:** This is currently still broken; it fails a supertrait test with`"#<C> is not a constructor`.  I haven't figured out what causes that yet.